### PR TITLE
画面追加：検索結果表示アイテム追加

### DIFF
--- a/lib/presenter/repository_list_item.dart
+++ b/lib/presenter/repository_list_item.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+/// GitHub リポジトリの検索結果を表示するリストアイテムウィジェット
+class RepositoryListItem extends StatelessWidget {
+  const RepositoryListItem({
+    required this.repository, super.key,
+    this.onTap,
+  });
+  /// リポジトリ情報を含むMap
+  final Map<String, dynamic> repository;
+
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) => Card(
+        elevation: 2,
+        margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+        child: ListTile(
+          contentPadding: const EdgeInsets.all(16),
+          title: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  // リポジトリアイコン
+                  const Icon(Icons.book, size: 20),
+                  const SizedBox(width: 8),
+
+                  // リポジトリ名
+                  Expanded(
+                    child: Text(
+                      repository['full_name'] ?? '',
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+
+              // リポジトリの説明がある場合は表示
+              if (repository['description'] != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  repository['description'],
+                  style: const TextStyle(fontSize: 14),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ],
+          ),
+
+          // サブタイトル
+          subtitle: Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Row(
+              children: [
+                // スター数
+                Row(
+                  children: [
+                    const Icon(Icons.star_border, size: 16),
+                    const SizedBox(width: 4),
+                    Text('${repository['stargazers_count'] ?? 0}'),
+                  ],
+                ),
+                const SizedBox(width: 16),
+
+                // フォーク数
+                Row(
+                  children: [
+                    const Icon(Icons.fork_right, size: 16),
+                    const SizedBox(width: 4),
+                    Text('${repository['forks_count'] ?? 0}'),
+                  ],
+                ),
+
+                // 言語
+                const SizedBox(width: 16),
+                if (repository['language'] != null)
+                  Row(
+                    children: [
+                      const Icon(Icons.code, size: 16),
+                      const SizedBox(width: 4),
+                      Text(repository['language']),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+          onTap: onTap,
+        ),
+      );
+}

--- a/lib/presenter/repository_list_item.dart
+++ b/lib/presenter/repository_list_item.dart
@@ -3,9 +3,11 @@ import 'package:flutter/material.dart';
 /// GitHub リポジトリの検索結果を表示するリストアイテムウィジェット
 class RepositoryListItem extends StatelessWidget {
   const RepositoryListItem({
-    required this.repository, super.key,
+    required this.repository,
+    super.key,
     this.onTap,
   });
+
   /// リポジトリ情報を含むMap
   final Map<String, dynamic> repository;
 

--- a/lib/presenter/search_screen.dart
+++ b/lib/presenter/search_screen.dart
@@ -17,7 +17,8 @@ class _SearchScreenState extends State<SearchScreen> {
   List<dynamic> _searchResults = [
     {
       'full_name': 'flutter/flutter',
-      'description': 'Flutter makes it easy and fast to build beautiful apps for mobile and beyond',
+      'description':
+          'Flutter makes it easy and fast to build beautiful apps for mobile and beyond',
       'stargazers_count': 158432,
       'forks_count': 25643,
       'language': 'Dart',
@@ -31,7 +32,8 @@ class _SearchScreenState extends State<SearchScreen> {
     },
     {
       'full_name': 'facebook/react',
-      'description': 'A declarative, efficient, and flexible JavaScript library for building user interfaces.',
+      'description':
+          'A declarative, efficient, and flexible JavaScript library for building user interfaces.',
       'stargazers_count': 203456,
       'forks_count': 42789,
       'language': 'JavaScript',

--- a/lib/presenter/search_screen.dart
+++ b/lib/presenter/search_screen.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_engineer_codecheck/presenter/repository_list_item.dart';
 
 /// GitHub Repository 検索画面
 class SearchScreen extends StatefulWidget {
-  const SearchScreen({Key? key}) : super(key: key);
+  const SearchScreen({super.key});
 
   @override
   State<SearchScreen> createState() => _SearchScreenState();
@@ -12,7 +13,30 @@ class _SearchScreenState extends State<SearchScreen> {
   // テキスト入力を管理するためのコントローラー
   final TextEditingController _searchTextController = TextEditingController();
   bool _isLoading = false;
-  List<dynamic> _searchResults = [];
+  // 仮の検索結果
+  List<dynamic> _searchResults = [
+    {
+      'full_name': 'flutter/flutter',
+      'description': 'Flutter makes it easy and fast to build beautiful apps for mobile and beyond',
+      'stargazers_count': 158432,
+      'forks_count': 25643,
+      'language': 'Dart',
+    },
+    {
+      'full_name': 'microsoft/vscode',
+      'description': 'Visual Studio Code',
+      'stargazers_count': 154321,
+      'forks_count': 28765,
+      'language': 'TypeScript',
+    },
+    {
+      'full_name': 'facebook/react',
+      'description': 'A declarative, efficient, and flexible JavaScript library for building user interfaces.',
+      'stargazers_count': 203456,
+      'forks_count': 42789,
+      'language': 'JavaScript',
+    }
+  ];
   String? _error;
 
   @override
@@ -59,7 +83,7 @@ class _SearchScreenState extends State<SearchScreen> {
         body: Column(
           children: [
             Padding(
-              padding: const EdgeInsets.all(16.0),
+              padding: const EdgeInsets.all(16),
               child: TextField(
                 controller: _searchTextController,
                 decoration: InputDecoration(
@@ -115,11 +139,11 @@ class _SearchScreenState extends State<SearchScreen> {
       itemCount: _searchResults.length,
       itemBuilder: (context, index) {
         final repository = _searchResults[index];
-        return Card(
-          child: ListTile(
-            // TODO: 検索結果 UI の実装
-            title: Text(repository.toString()),
-          ),
+        return RepositoryListItem(
+          repository: repository,
+          onTap: () {
+            // TODO: リポジトリ詳細画面への遷移機能の実装
+          },
         );
       },
     );


### PR DESCRIPTION
## 変更内容
検索結果表示アイテム追加

### 新機能  
- GitHub リポジトリ結果を表示するための視覚的に強化されたコンポーネントを導入しました。リポジトリの詳細（完全な名前、簡潔な説明（必要に応じて切り詰め）、スター数、フォーク数、使用言語）を直感的なアイコンとともに明確に表示します。  
- 検索インターフェースを更新し、サンプルリポジトリデータを事前に入力することで、ユーザーに即座にリポジトリリストを提供し、より魅力的なビューを提供しました。  

<!-- ## 関連イシュー
関連するイシュー番号を記入してください（例: #123） -->

## チェックリスト
- [x] コミットのサイズは適切ですか？
- [x] CIで問題は発生していませんか？
- [x] CodeRabbitからの指摘内容を確認しましたか？

## スクリーンショット（必要な場合）
変更内容を視覚的に示すスクリーンショットを追加してください。
<img width="240" src="https://github.com/user-attachments/assets/f4de5059-51d5-4ac3-8e1b-c562f9803661">

<!-- ## テスト方法
レビュアーが変更内容をテストする方法を説明してください。 -->

## 補足情報
レビュアーが知っておくべき追加情報があれば記入してください。 